### PR TITLE
Fixed - was not working for variables in last line of heredoc.

### DIFF
--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
@@ -413,7 +413,6 @@ sub get_token_content
 	if ( $token->isa('PPI::Token::HereDoc') )
 	{
 		my @heredoc = $token->heredoc();
-		pop( @heredoc ); # Remove the heredoc termination tag.
 		$content = join( '', @heredoc );
 	}
 	elsif ( $token->isa('PPI::Token::Quote' ) )

--- a/t/10-extract_variables.t
+++ b/t/10-extract_variables.t
@@ -16,6 +16,10 @@ my $tests =
 		expected => [ '$variable' ],
 	},
 	{
+		string   => "A test string\n with \$variable",
+		expected => [ '$variable' ],
+	},
+	{
 		string   => 'A test $variable $variable string',
 		expected => [ '$variable' ],
 	},

--- a/t/ValuesAndExpressions/PreventSQLInjection.run
+++ b/t/ValuesAndExpressions/PreventSQLInjection.run
@@ -104,6 +104,15 @@ my $heredoc = <<__HERE__
 	FROM $table
 __HERE__
 
+## name Heredoc with variable in last line
+## failures 1
+## cut
+
+my $heredoc = <<__HERE__
+	SELECT
+	FROM $table
+__HERE__
+
 ## name Double-quoted heredoc with multiple variables.
 ## failures 1
 ## cut


### PR DESCRIPTION
It seems that heredoc() method excludes terminator line, so no need to pop()
https://metacpan.org/pod/PPI::Token::HereDoc#heredoc

added test for the bug, also added additional test to extract_variables (just
to make sure our regexp deals with newlines right)
