### PR TITLE
reset `_sqlsafe` when scanning multiple documents; added tests

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -44,6 +44,7 @@ my $builder = $class->new(
 		'Test::Deep'                    => 0,
 		'Test::FailWarnings'            => 0,
 		'Test::More'                    => 0,
+		'Test::Perl::Critic'            => 0,
 		'Test::Perl::Critic::Policy'    => 0,
 	},
 	requires             =>

--- a/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
+++ b/lib/Perl/Critic/Policy/ValuesAndExpressions/PreventSQLInjection.pm
@@ -305,6 +305,20 @@ sub applies_to
 	);
 }
 
+=head2 prepare_to_scan_document()
+
+Sets up policy ($self) for each new document before scanning.
+
+	my $bool = $policy->prepare_to_scan_document();
+
+=cut
+
+sub prepare_to_scan_document {
+	my ( $self, $doc ) = @_;
+	delete $self->{'_sqlsafe'};
+    return $TRUE;
+}
+
 
 =head2 violates()
 

--- a/t/45-multi-docs.t
+++ b/t/45-multi-docs.t
@@ -1,0 +1,17 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::FailWarnings -allow_deps => 1;
+use Test::More tests => 2;
+use Test::Perl::Critic;
+use File::Spec;
+
+Test::Perl::Critic->import('-single-policy' => 'ValuesAndExpressions::PreventSQLInjection');
+
+my $testfile1 = File::Spec->catfile( 't', 'files', 'test10.pl' );
+my $testfile2 = File::Spec->catfile( 't', 'files', 'test11.pl' );
+
+all_critic_ok($testfile1, $testfile2 );
+

--- a/t/files/test10.pl
+++ b/t/files/test10.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+my $str = "just a placeholder";
+
+1;

--- a/t/files/test11.pl
+++ b/t/files/test11.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+my $username = "user1";
+my $sql = "select * from users WHERE user = $username"; ## SQL safe($username)
+


### PR DESCRIPTION
I was getting false positives for violations marked as safe, when scanning multiple documents.

I have overridden the `prepare_to_scan_document` method from `Perl::Critic::Policy` to reset the `_sqlsafe` attribute. Resetting the attribute for each document fixes the problem. 

I also added some tests. Running the test against the current version will fail. The tests pass with the changes in this PR.