### PR TITLE
Prevent false positives

### DIFF
--- a/t/ValuesAndExpressions/PreventSQLInjection.run
+++ b/t/ValuesAndExpressions/PreventSQLInjection.run
@@ -4,6 +4,22 @@
 
 my $string = "Hello $world";
 
+## name Prevent false positives in non-db operations
+## failures 0
+## cut
+
+die     "Select returned: $error";
+warn    "Update returned: $error";
+croak   "Insert returned: $error";
+carp    "Delete returned: $error";
+confess "Select returned: $error";
+
+do_something() or die     "Select returned: $error";
+do_something() or warn    "Update returned: $error";
+do_something() or croak   "Insert returned: $error";
+do_something() or carp    "Delete returned: $error";
+do_something() or confess "Select returned: $error";
+
 ## name Single-quoted SQL string with an escaped variable.
 ## failures 0
 ## cut


### PR DESCRIPTION
This pull request will prevent false positives in contexts that cannot generate SQL injections, for instance:

```
die     "Select returned: $error";
warn    "Update returned: $error";
croak   "Insert returned: $error";
carp    "Delete returned: $error";
confess "Select returned: $error";
```

It will always look at the previous significant sibling, so it will also prevent false positives like:

```
do_something() or die     "Select returned: $error";
do_something() or warn    "Update returned: $error";
do_something() or croak   "Insert returned: $error";
do_something() or carp    "Delete returned: $error";
do_something() or confess "Select returned: $error";
```